### PR TITLE
Allow handling a pch vector in new R version

### DIFF
--- a/R/plotCI.R
+++ b/R/plotCI.R
@@ -36,7 +36,7 @@ plotCI <- function (x, y = NULL, uiw, liw = uiw, ui = NULL, li = NULL,
         else scol <- par("col")
     }
     plotpoints <- TRUE
-    if (!is.null(arglist$pch) && is.na(arglist$pch)) {
+    if (!is.null(arglist$pch) && any(is.na(arglist$pch))) {
         arglist$pch <- 1
         plotpoints <- FALSE
     }


### PR DESCRIPTION
Recent R versions throw errors when supplying plotCI() with a pch argument that is a vector. This is because the if condition on line 39 cannot handle a vector (anymore). Surrounding the is.na() in this line with an any() call prevents this problem. This way, plotCI() can still be used with a vector pch argument in newer R versions.