### PR TITLE
Fix brkdn.plot() two-term formula and histStack() legend.pos handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: plotrix
-Version: 3.8-14
+Version: 3.8-15
 Title: Various Plotting Functions
 Authors@R: c(
   person("Jim", "Lemon", role = "aut"),

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,16 @@
+Changes in version 3.8-15 (unreleased)
+
+  - Fixed `brkdn.plot()` crashing when called with a two-term formula
+  such as `var ~ groups` (no `obs` term). The formula handler now leaves
+  `obs` as NULL when no third term is present, and the downstream
+  dispatch uses `is.null()` (rather than `is.na()`) for the `obs` and
+  `xlab` arguments, which default to NULL.
+
+  - Fixed `histStack()` routing a single keyword `legend.pos` (e.g.
+  `"topright"`) into the coordinate branch because of a misplaced
+  parenthesis in `length(legend.pos > 1)`. The check is now
+  `length(legend.pos) > 1`.
+
 Changes in version 3.8.14 (2026-02-13)
 
   - Fixed mis-handling of `labels = ""` in `polar.plot()` (issue #19).

--- a/R/brkdn.plot.R
+++ b/R/brkdn.plot.R
@@ -6,7 +6,9 @@ brkdn.plot<-function(vars,groups=NULL,obs=NULL,data,mct="mean",md="std.error",
   formbits<-all.vars(vars)
   vars<-formbits[1]
   groups<-formbits[2]
-  obs<-formbits[3]
+  # only assign obs when a third term (e.g. var~groups+obs) is present,
+  # so a two-term formula leaves obs as NULL rather than NA_character_.
+  if(length(formbits) > 2) obs<-formbits[3]
  }
  if(is.null(obs)) {
   if(is.null(groups[1]))
@@ -64,8 +66,8 @@ brkdn.plot<-function(vars,groups=NULL,obs=NULL,data,mct="mean",md="std.error",
   }
  }
  else {
-  if(is.na(obs)) {
-   if(is.na(xlab)) xlab<-"Variable"
+  if(is.null(obs)) {
+   if(is.null(xlab)) xlab<-"Variable"
    xat<-1:length(vars)
    if(is.na(xaxlab[1])) xaxlab<-vars
    for(group in 1:ngroups) {

--- a/R/histStack.R
+++ b/R/histStack.R
@@ -30,7 +30,7 @@ histStack.default<-function(x,z,breaks="Sturges",col="rainbow",right=TRUE,
   hist(x[z %in% seps[-(1:i)]],breaks=hS$breaks,col=col[i+1],
   right=right,add=TRUE)
  if(!is.null(legend.pos)) {
-  if(length(legend.pos > 1))
+  if(length(legend.pos) > 1)
    legend(legend.pos[1],legend.pos[2],seps,fill=col,cex=cex.legend)
   else legend(legend.pos,seps,fill=col,cex=cex.legend)
  }

--- a/tests/regression-tests.R
+++ b/tests/regression-tests.R
@@ -1,0 +1,87 @@
+## Focused regression tests for argument-handling fixes.
+##
+## These tests exercise the public plotting API for two defects:
+##   1. brkdn.plot() with a two-term formula such as `a ~ group` (no `obs`
+##      term) used to crash with "argument is of length zero" because the
+##      formula handler set `obs` to NA_character_ and downstream branches
+##      used `is.na(obs)` / `is.na(xlab)` on arguments that default to NULL.
+##   2. histStack() used `length(legend.pos > 1)`, which routes a single
+##      keyword such as "topright" into the coordinate branch and breaks
+##      the call.
+##
+## The tests intentionally avoid brittle visual assertions: they only check
+## that the calls run to completion and produce values with the documented
+## structure / dimensions. Plots are sent to a throwaway PDF device so the
+## tests can run headless under R CMD check.
+
+library(plotrix)
+
+pdf(file = tempfile(fileext = ".pdf"))
+on.exit(dev.off(), add = TRUE)
+
+## ---------------------------------------------------------------------------
+## brkdn.plot: two-term formula
+## ---------------------------------------------------------------------------
+test.df <- data.frame(a = rnorm(80) + 4, b = rnorm(80) + 4,
+                      c = rep(LETTERS[1:4], each = 20),
+                      d = rep(rep(letters[1:4], each = 4), 5))
+
+## A two-term formula `a ~ c` must not error. It must produce a result with
+## one row per group and one column (the single variable), per the
+## documented semantics ("if obs is NULL, the rows will be the groups and
+## the columns the vars").
+bp_two <- brkdn.plot(a ~ c, data = test.df)
+stopifnot(is.list(bp_two), length(bp_two) == 2L)
+stopifnot(identical(dim(bp_two[[1]]), c(4L, 1L)))
+## the means per group must equal tapply's means (sanity check on values)
+ref_means <- as.numeric(tapply(test.df$a, test.df$c, mean))
+stopifnot(all.equal(as.numeric(bp_two[[1]]), ref_means, tolerance = 1e-8))
+
+## The default xlab for this path is "Variable"; just ensure the call
+## succeeds without the user having to pass xlab (this is the exact
+## regression - xlab defaults to NULL and `is.na(NULL)` used to crash).
+stopifnot(inherits(try(brkdn.plot(a ~ c, data = test.df), silent = TRUE),
+                   "list"))
+
+## ---------------------------------------------------------------------------
+## brkdn.plot: regression - three-term formula still works
+## ---------------------------------------------------------------------------
+bp_three <- brkdn.plot(a ~ c + d, data = test.df)
+stopifnot(identical(dim(bp_three[[1]]), c(4L, 4L)))
+
+## ---------------------------------------------------------------------------
+## brkdn.plot: regression - string API with both factors still works
+## ---------------------------------------------------------------------------
+bp_str <- brkdn.plot("a", "c", "d", test.df)
+stopifnot(identical(dim(bp_str[[1]]), c(4L, 4L)))
+
+## ---------------------------------------------------------------------------
+## brkdn.plot: regression - multiple vars broken down by groups (no obs)
+## exercises the adjacent `is.null(xlab)` branch that used to use is.na().
+## ---------------------------------------------------------------------------
+bp_multi <- brkdn.plot(c("a", "b"), "c", data = test.df)
+stopifnot(identical(dim(bp_multi[[1]]), c(4L, 2L)))
+
+## ---------------------------------------------------------------------------
+## histStack: legend.pos routing
+## ---------------------------------------------------------------------------
+df <- data.frame(len = rnorm(100) + 5,
+                 grp = factor(sample(c("A", "B", "C", "D"), 100,
+                                     replace = TRUE)))
+
+## A single keyword must route to legend(x, ...) and run without error.
+## histStack returns NULL invisibly, so we check the call did not error.
+stopifnot(!inherits(try(histStack(len ~ grp, data = df,
+                                  legend.pos = "topright"),
+                        silent = TRUE), "try-error"))
+
+## A length-2 numeric vector must route to legend(x, y, ...) and run.
+stopifnot(!inherits(try(histStack(len ~ grp, data = df,
+                                  legend.pos = c(2.8, 18)),
+                        silent = TRUE), "try-error"))
+
+## No legend at all still works.
+stopifnot(!inherits(try(histStack(len ~ grp, data = df),
+                        silent = TRUE), "try-error"))
+
+cat("regression-tests.R: all assertions passed\n")


### PR DESCRIPTION
brkdn.plot() crashed with "argument is of length zero" when called with a two-term formula such as 'var ~ groups' (no 'obs' term): the formula handler set obs to NA_character_ via out-of-bounds indexing, and the downstream dispatch then used is.na(obs) / is.na(xlab) on arguments that default to NULL, where is.na(NULL) returns logical(0).

- R/brkdn.plot.R: only assign obs from the formula when a third term is present, so a two-term formula leaves obs as NULL as the rest of the function already assumes. Switch the matching dispatch branch and its adjacent xlab default to is.null(), consistent with the other two branches and with the NULL defaults of obs and xlab.

histStack() used length(legend.pos > 1), which compares legend.pos to 1 first and takes length() of the resulting logical vector. For a single keyword such as "topright" the comparison yields NA (length 1), routing the keyword into the coordinate branch and breaking the legend call.

- R/histStack.R: use length(legend.pos) > 1 so keyword positions use legend(x, ...) and length-2 numeric positions use legend(x, y, ...).

- tests/regression-tests.R: new focused, non-visual regression tests for the two-term formula path (including value checks against tapply), the existing three-term / string-API paths, and both keyword and numeric legend.pos routing in histStack().

- Bump version to 3.8-15 and add NEWS entries.

Found during my large https://github.com/sims1253/ry audit